### PR TITLE
Propagating authorization bit mask on DATA frame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 
     <junit.version>4.12</junit.version>
 
-    <k3po.version>3.0.0-alpha-88</k3po.version>
-    <k3po.nukleus.ext.version>0.23</k3po.nukleus.ext.version>
+    <k3po.version>3.0.0-alpha-96</k3po.version>
+    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <junit.version>4.12</junit.version>
 
     <k3po.version>3.0.0-alpha-96</k3po.version>
-    <k3po.nukleus.ext.version>develop-SNAPSHOT</k3po.nukleus.ext.version>
+    <k3po.nukleus.ext.version>0.27</k3po.nukleus.ext.version>
 
     <nukleus.plugin.version>0.28</nukleus.plugin.version>
     <nukleus.version>0.21</nukleus.version>

--- a/src/main/java/org/reaktivity/nukleus/auth/jwt/internal/stream/ProxyStreamFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/auth/jwt/internal/stream/ProxyStreamFactory.java
@@ -176,7 +176,13 @@ public class ProxyStreamFactory implements StreamFactory
                 }
             }
         });
-         return authorization[0];
+
+        if (authorization[0] == 0L)
+        {
+            authorization[0] = begin.authorization();
+        }
+
+        return authorization[0];
     }
 
     private MessageConsumer newConnectReplyStream(
@@ -295,7 +301,8 @@ public class ProxyStreamFactory implements StreamFactory
                 DataFW data)
         {
             final OctetsFW payload = data.payload();
-            writer.doData(target, targetStreamId, data.groupId(), data.padding(), payload, data.extension());
+            writer.doData(target, targetStreamId, data.authorization(), data.groupId(), data.padding(),
+                    payload, data.extension());
         }
 
         private void handleEnd(

--- a/src/main/java/org/reaktivity/nukleus/auth/jwt/internal/stream/Writer.java
+++ b/src/main/java/org/reaktivity/nukleus/auth/jwt/internal/stream/Writer.java
@@ -72,14 +72,15 @@ public class Writer
     public void doData(
         MessageConsumer target,
         long targetStreamId,
+        long authorization,
         long groupId,
         int padding,
         OctetsFW payload,
         OctetsFW extension)
     {
-
         DataFW data = dataRW.wrap(writeBuffer, 0, writeBuffer.capacity())
                             .streamId(targetStreamId)
+                            .authorization(authorization)
                             .groupId(groupId)
                             .padding(padding)
                             .payload(payload)


### PR DESCRIPTION
* Propagating authorization bit mask on DATA frame
* If BEGIN has authorization bit mask but not Authorization header, then the
bit mask is used for routing