### PR TITLE
Support JWT tokens with multi-valued audience claim #26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.oauth.spec.version>0.24</nukleus.oauth.spec.version>
+    <nukleus.oauth.spec.version>develop-SNAPSHOT</nukleus.oauth.spec.version>
     <reaktor.version>0.93</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.oauth.spec.version>develop-SNAPSHOT</nukleus.oauth.spec.version>
+    <nukleus.oauth.spec.version>0.25</nukleus.oauth.spec.version>
     <reaktor.version>0.93</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
@@ -88,6 +88,19 @@ public class OAuthController implements Controller
         return OAuthNukleus.NAME;
     }
 
+//    public CompletableFuture<Long> resolve(
+//            String realmName)
+//    {
+//        return resolve(realmName, null, null, null);
+//    }
+//
+//    public CompletableFuture<Long> resolve(
+//            String realmName,
+//            String[] roleNames)
+//    {
+//        return resolve(realmName, roleNames, null, null);
+//    }
+
     public CompletableFuture<Long> resolve(
         String realmName,
         String... roleNames)

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
@@ -88,19 +88,6 @@ public class OAuthController implements Controller
         return OAuthNukleus.NAME;
     }
 
-//    public CompletableFuture<Long> resolve(
-//            String realmName)
-//    {
-//        return resolve(realmName, null, null, null);
-//    }
-//
-//    public CompletableFuture<Long> resolve(
-//            String realmName,
-//            String[] roleNames)
-//    {
-//        return resolve(realmName, roleNames, null, null);
-//    }
-
     public CompletableFuture<Long> resolve(
         String realmName,
         String... roleNames)

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
@@ -351,9 +351,30 @@ public class OAuthRealms
                     String issuerName,
                     String[] audienceNames)
                 {
-                    return (this.issuerName == null || Objects.equals(this.issuerName, issuerName))
-                            && (this.audienceName == null
-                            || (audienceNames != null && Arrays.asList(audienceNames).contains(this.audienceName)));
+                    return (this.issuerName == null || Objects.equals(this.issuerName, issuerName)) &&
+                            (this.audienceName == null || (audienceNames != null && containsThisAudienceName(audienceNames)));
+                }
+
+                private boolean containsThisAudienceName(
+                    String[] audienceNames)
+                {
+                    final int index = indexOfThisAudienceName(audienceNames);
+                    return index >= 0 && audienceNames[indexOfThisAudienceName(audienceNames)].equals(this.audienceName);
+                }
+
+                private int indexOfThisAudienceName(
+                    String[] audienceNames)
+                {
+                    int index = -1;
+                    for(int i = 0 ; i < audienceNames.length; i++)
+                    {
+                        if(audienceNames[i].equals(this.audienceName))
+                        {
+                            index = i;
+                            break;
+                        }
+                    }
+                    return index;
                 }
 
                 @Override

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
@@ -24,7 +24,6 @@ import static org.jose4j.jwt.ReservedClaimNames.ISSUER;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -366,7 +365,7 @@ public class OAuthRealms
                     String[] audienceNames)
                 {
                     int index = -1;
-                    for(int i = 0 ; i < audienceNames.length; i++)
+                    for(int i = 0; i < audienceNames.length; i++)
                     {
                         if(audienceNames[i].equals(this.audienceName))
                         {

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
@@ -18,6 +18,8 @@ package org.reaktivity.nukleus.oauth.internal;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.unmodifiableMap;
 import static org.agrona.LangUtil.rethrowUnchecked;
+import static org.jose4j.jwt.ReservedClaimNames.AUDIENCE;
+import static org.jose4j.jwt.ReservedClaimNames.ISSUER;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,7 +37,6 @@ import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.jwt.JwtClaims;
-import org.jose4j.jwt.ReservedClaimNames;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.lang.JoseException;
 import org.reaktivity.nukleus.internal.CopyOnWriteHashMap;
@@ -99,8 +100,8 @@ public class OAuthRealms
             try
             {
                 final JwtClaims claims = JwtClaims.parse(verified.getPayload());
-                final Object issuerClaim = claims.getClaimValue(ReservedClaimNames.ISSUER);
-                final Object audienceClaim = claims.getClaimValue(ReservedClaimNames.AUDIENCE);
+                final Object issuerClaim = claims.getClaimValue(ISSUER);
+                final Object audienceClaim = claims.getClaimValue(AUDIENCE);
                 final Object scopeClaim = claims.getClaimValue(SCOPE_CLAIM);
                 final String issuerName = issuerClaim != null ? issuerClaim.toString() : null;
                 final String[] audienceNames = audienceClaim != null ? audienceClaim.toString().split("\\s+") : null;
@@ -350,11 +351,9 @@ public class OAuthRealms
                     String issuerName,
                     String[] audienceNames)
                 {
-
-                    return Objects.equals(this.issuerName, issuerName)
-                            && audienceNames != null ? Arrays.asList(audienceNames).contains(this.audienceName)
-                            // TODO: NOT AS NULL
-                            : Objects.equals(this.audienceName, null);
+                    return (this.issuerName == null || Objects.equals(this.issuerName, issuerName))
+                            && (this.audienceName == null
+                            || (audienceNames != null && Arrays.asList(audienceNames).contains(this.audienceName)));
                 }
 
                 @Override

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/stream/OAuthProxyFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/stream/OAuthProxyFactory.java
@@ -20,9 +20,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.reaktivity.nukleus.oauth.internal.util.BufferUtil.indexOfBytes;
 
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.LongSupplier;

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/OAuthRealmsTest.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/OAuthRealmsTest.java
@@ -73,17 +73,17 @@ public class OAuthRealmsTest
     public void shouldResolveKnownRealmWithDifferentKidAndDifferentClaims() throws Exception
     {
         OAuthRealms realms = new OAuthRealms();
-        realms.resolve("realm one", "test issuer1", "test audience1", EMPTY_STRING_ARRAY);
-        realms.resolve("realm two", "test issuer2", "test audience2", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer1", "testAudience1", EMPTY_STRING_ARRAY);
+        realms.resolve("realm two", "test issuer2", "testAudience2", EMPTY_STRING_ARRAY);
 
         JwtClaims claims1 = new JwtClaims();
         claims1.setClaim("iss", "test issuer1");
-        claims1.setClaim("aud", "test audience1");
+        claims1.setClaim("aud", "testAudience1");
         String payload1 = claims1.toJson();
 
         JwtClaims claims2 = new JwtClaims();
         claims2.setClaim("iss", "test issuer2");
-        claims2.setClaim("aud", "test audience2");
+        claims2.setClaim("aud", "testAudience2");
         String payload2 = claims2.toJson();
 
         final JsonWebSignature signatureOne = newSignedSignature("realm one", "RS256", payload1, RFC7515_RS256);
@@ -97,17 +97,17 @@ public class OAuthRealmsTest
     public void shouldResolveKnownRealmWithSameKidButDifferentClaims() throws Exception
     {
         OAuthRealms realms = new OAuthRealms();
-        realms.resolve("realm one", "test issuer1", "test audience1", EMPTY_STRING_ARRAY);
-        realms.resolve("realm one", "test issuer2", "test audience2", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer1", "testAudience1", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer2", "testAudience2", EMPTY_STRING_ARRAY);
 
         JwtClaims claims1 = new JwtClaims();
         claims1.setClaim("iss", "test issuer1");
-        claims1.setClaim("aud", "test audience1");
+        claims1.setClaim("aud", "testAudience1");
         String payload1 = claims1.toJson();
 
         JwtClaims claims2 = new JwtClaims();
         claims2.setClaim("iss", "test issuer2");
-        claims2.setClaim("aud", "test audience2");
+        claims2.setClaim("aud", "testAudience2");
         String payload2 = claims2.toJson();
 
         final JsonWebSignature signatureOne = newSignedSignature("realm one", "RS256", payload1, RFC7515_RS256);
@@ -121,17 +121,17 @@ public class OAuthRealmsTest
     public void shouldUnresolveKnownRealmWithSameKidButDifferentClaims() throws Exception
     {
         OAuthRealms realms = new OAuthRealms();
-        realms.resolve("realm one", "test issuer1", "test audience1", EMPTY_STRING_ARRAY);
-        realms.resolve("realm one", "test issuer2", "test audience2", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer1", "testAudience1", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer2", "testAudience2", EMPTY_STRING_ARRAY);
 
         JwtClaims claims1 = new JwtClaims();
         claims1.setClaim("iss", "test issuer1");
-        claims1.setClaim("aud", "test audience1");
+        claims1.setClaim("aud", "testAudience1");
         String payload1 = claims1.toJson();
 
         JwtClaims claims2 = new JwtClaims();
         claims2.setClaim("iss", "test issuer2");
-        claims2.setClaim("aud", "test audience2");
+        claims2.setClaim("aud", "testAudience2");
         String payload2 = claims2.toJson();
 
         final JsonWebSignature signatureOne = newSignedSignature("realm one", "RS256", payload1, RFC7515_RS256);
@@ -145,11 +145,11 @@ public class OAuthRealmsTest
     public void shouldFailTooManyUnresolves() throws Exception
     {
         OAuthRealms realms = new OAuthRealms();
-        realms.resolve("realm one", "test issuer", "test audience", EMPTY_STRING_ARRAY);
+        realms.resolve("realm one", "test issuer", "testAudience", EMPTY_STRING_ARRAY);
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("iss", "test issuer");
-        claims.setClaim("aud", "test audience");
+        claims.setClaim("aud", "testAudience");
         String payload = claims.toJson();
 
         final JsonWebSignature signatureOne = newSignedSignature("realm one", "RS256", payload, RFC7515_RS256);

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
@@ -79,11 +79,11 @@ public class ControllerIT
 
         reaktor.controller(OAuthController.class)
           .resolve("RS256",
-                  "role1", "role2", "role3", "role4", "role5", "role6", "role7", "role8", "role9", "role10",
+                  new String[]{"role1", "role2", "role3", "role4", "role5", "role6", "role7", "role8", "role9", "role10",
                   "role11", "role12", "role13", "role14", "role15", "role16", "role17", "role18", "role19", "role20",
                   "role21", "role22", "role23", "role24", "role25", "role26", "role27", "role28", "role29", "role30",
                   "role31", "role32", "role33", "role34", "role35", "role36", "role37", "role38", "role39", "role40",
-                  "role41", "role42", "role43", "role44", "role45", "role46", "role47", "role48", "role49TooMany")
+                  "role41", "role42", "role43", "role44", "role45", "role46", "role47", "role48", "role49TooMany"})
           .get();
 
         k3po.finish();
@@ -233,7 +233,7 @@ public class ControllerIT
         k3po.start();
 
         long authorization = reaktor.controller(OAuthController.class)
-            .resolve("RS256", "scope1", "scope2", "scope3")
+            .resolve("RS256", new String[]{"scope1", "scope2", "scope3"})
             .get();
         assertEquals(0x0001_000000000007L, authorization);
 
@@ -249,7 +249,7 @@ public class ControllerIT
         k3po.start();
 
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", EMPTY_STRING_ARRAY, "test issuer", "test audience")
+                .resolve("RS256", EMPTY_STRING_ARRAY, "test issuer", "testAudience")
                 .get();
         assertEquals(0x0001_000000000000L, authorization);
 
@@ -265,7 +265,7 @@ public class ControllerIT
         k3po.start();
 
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, "test issuer", "test audience")
+                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, "test issuer", "testAudience")
                 .get();
         assertEquals(0x0001_000000000007L, authorization);
 
@@ -388,7 +388,7 @@ public class ControllerIT
         k3po.start();
 
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", "scope1", "scope2", "scope3")
+                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"})
                 .get();
         assertEquals(0x0001_000000000007L, authorization);
 

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
@@ -232,7 +232,7 @@ public class StreamsIT
         "${streams}/request.with.scopes.issuer.and.audience.with.signed.jwt.rs256.forwarded/accept/client",
         "${streams}/request.with.scopes.issuer.and.audience.with.signed.jwt.rs256.forwarded/connect/server"
     })
-    public void shouldForwardRequestWithATokenWithIssuerOrAudienceWithoutThmeOnSecuredRoute() throws Exception
+    public void shouldForwardRequestWithATokenWithIssuerOrAudienceWithoutSpecifiedClaimsOnTheSecuredRoute() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
@@ -228,6 +228,17 @@ public class StreamsIT
 
     @Test
     @Specification({
+        "${route}/resolve.one.realm.with.set.roles.then.route.proxy/controller",
+        "${streams}/request.with.scopes.issuer.and.audience.with.signed.jwt.rs256.forwarded/accept/client",
+        "${streams}/request.with.scopes.issuer.and.audience.with.signed.jwt.rs256.forwarded/connect/server"
+    })
+    public void shouldForwardRequestWithATokenWithIssuerOrAudienceWithoutThmeOnSecuredRoute() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/resolve.one.realm.with.set.roles.and.audience.and.no.issuer.then.route.proxy/controller",
         "${streams}/request.with.scopes.and.audience.and.no.issuer.with.signed.jwt.rs256.forwarded/accept/client",
         "${streams}/request.with.scopes.and.audience.and.no.issuer.with.signed.jwt.rs256.forwarded/connect/server"
@@ -245,6 +256,17 @@ public class StreamsIT
     })
     public void shouldForwardRequestWithSetScopesAndMultipleAudiencesWithNoIssuerWithValidJwtRS256OnSecuredRoute()
     throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/resolve.one.realm.with.issuer.and.audience.expect.no.authorization.then.route.proxy/controller",
+        "${streams}/request.without.issuer.and.audience.with.signed.jwt.rs256.forwarded/accept/client",
+        "${streams}/request.without.issuer.and.audience.with.signed.jwt.rs256.forwarded/connect/server"
+    })
+    public void shouldForwardRequestWithoutIssuerOrAudienceWithValidJwtRS256OnSecuredRoute() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/streams/StreamsIT.java
@@ -239,6 +239,18 @@ public class StreamsIT
 
     @Test
     @Specification({
+        "${route}/resolve.one.realm.with.set.roles.and.audience.and.no.issuer.then.route.proxy/controller",
+        "${streams}/request.with.scopes.and.multiple.audiences.and.no.issuer.with.signed.jwt.rs256.forwarded/accept/client",
+        "${streams}/request.with.scopes.and.multiple.audiences.and.no.issuer.with.signed.jwt.rs256.forwarded/connect/server"
+    })
+    public void shouldForwardRequestWithSetScopesAndMultipleAudiencesWithNoIssuerWithValidJwtRS256OnSecuredRoute()
+    throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
         "${route}/resolve.one.realm.with.no.roles.then.route.proxy/controller",
         "${streams}/request.with.signed.jwt.rs256.forwarded/accept/client",
         "${streams}/request.with.signed.jwt.rs256.forwarded/connect/server"


### PR DESCRIPTION
Changed `aud` from being a String to a space-delimited String to be parsed into an array to conform to the RFC standard.