### PR TITLE
Further enhance token matching for issuer and audience #27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.oauth.spec.version>0.25</nukleus.oauth.spec.version>
+    <nukleus.oauth.spec.version>develop-SNAPSHOT</nukleus.oauth.spec.version>
     <reaktor.version>0.93</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 
     <nukleus.plugin.version>0.33</nukleus.plugin.version>
 
-    <nukleus.oauth.spec.version>develop-SNAPSHOT</nukleus.oauth.spec.version>
+    <nukleus.oauth.spec.version>0.25</nukleus.oauth.spec.version>
     <reaktor.version>0.93</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
@@ -358,7 +358,7 @@ public class OAuthRealms
                     String[] audienceNames)
                 {
                     final int index = indexOfThisAudienceName(audienceNames);
-                    return index >= 0 && audienceNames[indexOfThisAudienceName(audienceNames)].equals(this.audienceName);
+                    return index >= 0 && audienceNames[index].equals(this.audienceName);
                 }
 
                 private int indexOfThisAudienceName(

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthRealms.java
@@ -351,7 +351,7 @@ public class OAuthRealms
                     String[] audienceNames)
                 {
                     return (this.issuerName == null || Objects.equals(this.issuerName, issuerName)) &&
-                            (this.audienceName == null || (audienceNames != null && containsThisAudienceName(audienceNames)));
+                            (this.audienceName == null || containsThisAudienceName(audienceNames));
                 }
 
                 private boolean containsThisAudienceName(
@@ -365,12 +365,15 @@ public class OAuthRealms
                     String[] audienceNames)
                 {
                     int index = -1;
-                    for(int i = 0; i < audienceNames.length; i++)
+                    if(audienceNames != null)
                     {
-                        if(audienceNames[i].equals(this.audienceName))
+                        for (int i = 0; i < audienceNames.length; i++)
                         {
-                            index = i;
-                            break;
+                            if (audienceNames[i].equals(this.audienceName))
+                            {
+                                index = i;
+                                break;
+                            }
                         }
                     }
                     return index;


### PR DESCRIPTION
Changed `compareClaims` methods to take into consideration if `issuerName` and `audienceName` are specified on a route. If they are not specified, then any token that matches the `realm` and `scope` should be authorized, regardless if `iss` or `aud` are present in the token. The opposite would be true, if they are specified then any token without the proper `iss` and `aud`.