### PR TITLE
Simplify OAuthController API to prevent ambiguous usage #25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
       <version>0.6.5</version>

--- a/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
+++ b/src/main/java/org/reaktivity/nukleus/oauth/internal/OAuthController.java
@@ -18,8 +18,6 @@ package org.reaktivity.nukleus.oauth.internal;
 import static java.nio.ByteBuffer.allocateDirect;
 import static java.nio.ByteOrder.nativeOrder;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.jose4j.jwt.ReservedClaimNames.AUDIENCE;
-import static org.jose4j.jwt.ReservedClaimNames.ISSUER;
 import static org.reaktivity.nukleus.route.RouteKind.PROXY;
 
 import java.util.Arrays;
@@ -119,7 +117,7 @@ public class OAuthController implements Controller
         String extension)
     {
         String issuerName = null;
-        String audienceNames = null;
+        String audienceName = null;
         if(extension != null)
         {
             final JsonParser parser = new JsonParser();
@@ -127,8 +125,8 @@ public class OAuthController implements Controller
             if(element.isJsonObject())
             {
                 final JsonObject object = (JsonObject) element;
-                issuerName = gson.fromJson(object.get(ISSUER), String.class);
-                audienceNames = gson.fromJson(object.get(AUDIENCE), String.class);
+                issuerName = gson.fromJson(object.get("issuer"), String.class);
+                audienceName = gson.fromJson(object.get("audience"), String.class);
             }
         }
 
@@ -138,16 +136,16 @@ public class OAuthController implements Controller
                 .nukleus(name())
                 .realm(realmName)
                 .roles(b -> Arrays.asList(roleNames).forEach(s -> b.item(sb -> sb.set(s, UTF_8))));
-        if (issuerName != null || audienceNames != null)
+        if (issuerName != null || audienceName != null)
         {
             final OAuthResolveExFW resolveEx = resolveExRW.wrap(extensionBuffer, 0, extensionBuffer.capacity())
                     .issuer(issuerName)
-                    .audience(audienceNames)
+                    .audience(audienceName)
                     .build();
             resolveBuilder.extension(resolveEx.buffer(), resolveEx.offset(), resolveEx.sizeof());
         }
         final ResolveFW resolve = resolveBuilder.build();
-        return  controllerSpi.doResolve(resolve.typeId(), resolve.buffer(), resolve.offset(), resolve.sizeof());
+        return controllerSpi.doResolve(resolve.typeId(), resolve.buffer(), resolve.offset(), resolve.sizeof());
     }
 
     public CompletableFuture<Void> unresolve(

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
@@ -250,8 +250,8 @@ public class ControllerIT
         k3po.start();
 
         JwtClaims claims = new JwtClaims();
-        claims.setClaim("iss", "test issuer");
-        claims.setClaim("aud", "testAudience");
+        claims.setClaim("issuer", "test issuer");
+        claims.setClaim("audience", "testAudience");
         String payload = claims.toJson();
 
         long authorization = reaktor.controller(OAuthController.class)
@@ -271,8 +271,8 @@ public class ControllerIT
         k3po.start();
 
         JwtClaims claims = new JwtClaims();
-        claims.setClaim("iss", "test issuer");
-        claims.setClaim("aud", "testAudience");
+        claims.setClaim("issuer", "test issuer");
+        claims.setClaim("audience", "testAudience");
         String payload = claims.toJson();
 
         long authorization = reaktor.controller(OAuthController.class)

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
@@ -253,10 +253,10 @@ public class ControllerIT
     {
         k3po.start();
 
-        JsonObject object = new JsonObject();
-        putValueIntoJsonObject(object, "issuer", "test issuer");
-        putValueIntoJsonObject(object, "audience", "testAudience");
-        String extension = object.toString();
+        final JsonObject object = new JsonObject();
+        object.addProperty("issuer", "test issuer");
+        object.addProperty("audience", "testAudience");
+        final String extension = object.toString();
 
         long authorization = reaktor.controller(OAuthController.class)
                 .resolve("RS256", EMPTY_STRING_ARRAY, extension)
@@ -274,10 +274,10 @@ public class ControllerIT
     {
         k3po.start();
 
-        JsonObject object = new JsonObject();
-        putValueIntoJsonObject(object, "issuer", "test issuer");
-        putValueIntoJsonObject(object, "audience", "testAudience");
-        String extension = object.toString();
+        final JsonObject object = new JsonObject();
+        object.addProperty("issuer", "test issuer");
+        object.addProperty("audience", "testAudience");
+        final String extension = object.toString();
 
         long authorization = reaktor.controller(OAuthController.class)
                 .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, extension)
@@ -472,13 +472,5 @@ public class ControllerIT
                .get();
 
         k3po.finish();
-    }
-
-    private void putValueIntoJsonObject(
-        JsonObject object,
-        String key,
-        String value)
-    {
-        object.add(key, gson.toJsonTree(value));
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
@@ -253,13 +253,12 @@ public class ControllerIT
     {
         k3po.start();
 
-        final JsonObject object = new JsonObject();
-        object.addProperty("issuer", "test issuer");
-        object.addProperty("audience", "testAudience");
-        final String extension = object.toString();
+        final JsonObject extension = new JsonObject();
+        extension.addProperty("issuer", "test issuer");
+        extension.addProperty("audience", "testAudience");
 
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", EMPTY_STRING_ARRAY, extension)
+                .resolve("RS256", EMPTY_STRING_ARRAY, gson.toJson(extension))
                 .get();
         assertEquals(0x0001_000000000000L, authorization);
 
@@ -274,13 +273,12 @@ public class ControllerIT
     {
         k3po.start();
 
-        final JsonObject object = new JsonObject();
-        object.addProperty("issuer", "test issuer");
-        object.addProperty("audience", "testAudience");
-        final String extension = object.toString();
+        final JsonObject extension = new JsonObject();
+        extension.addProperty("issuer", "test issuer");
+        extension.addProperty("audience", "testAudience");
 
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, extension)
+                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, gson.toJson(extension))
                 .get();
         assertEquals(0x0001_000000000007L, authorization);
 

--- a/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
+++ b/src/test/java/org/reaktivity/nukleus/oauth/internal/control/ControllerIT.java
@@ -27,6 +27,7 @@ import static org.reaktivity.nukleus.route.RouteKind.PROXY;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
+import org.jose4j.jwt.JwtClaims;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.DisableOnDebug;
@@ -248,8 +249,13 @@ public class ControllerIT
     {
         k3po.start();
 
+        JwtClaims claims = new JwtClaims();
+        claims.setClaim("iss", "test issuer");
+        claims.setClaim("aud", "testAudience");
+        String payload = claims.toJson();
+
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", EMPTY_STRING_ARRAY, "test issuer", "testAudience")
+                .resolve("RS256", EMPTY_STRING_ARRAY, payload)
                 .get();
         assertEquals(0x0001_000000000000L, authorization);
 
@@ -264,8 +270,13 @@ public class ControllerIT
     {
         k3po.start();
 
+        JwtClaims claims = new JwtClaims();
+        claims.setClaim("iss", "test issuer");
+        claims.setClaim("aud", "testAudience");
+        String payload = claims.toJson();
+
         long authorization = reaktor.controller(OAuthController.class)
-                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, "test issuer", "testAudience")
+                .resolve("RS256", new String[]{"scope1", "scope2", "scope3"}, payload)
                 .get();
         assertEquals(0x0001_000000000007L, authorization);
 


### PR DESCRIPTION
added gson dependency. updated `OAuthController` API to now not be ambiguous when its commands are called.